### PR TITLE
Migrate bevy_fog_of_war to Bevy 0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,31 +3,46 @@
 version = 4
 
 [[package]]
-name = "accesskit"
-version = "0.18.0"
+name = "ab_glyph"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "becf0eb5215b6ecb0a739c31c21bd83c4f326524c9b46b7e882d77559b60a529"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
+name = "accesskit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.27.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bf66a7bf0b7ea4fd7742d50b64782a88f99217cf246b3f93b4162528dde520"
+checksum = "db81010a6895d8707f9072e6ce98070579b43b717193d2614014abd5cb17dd43"
 dependencies = [
  "accesskit",
- "hashbrown",
- "immutable-chunkmap",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.19.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e230718177753b4e4ad9e1d9f6cfc2f4921212d4c1c480b253f526babb258d"
+checksum = "a0089e5c0ac0ca281e13ea374773898d9354cc28d15af9f0f7394d44a495b575"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown",
+ "hashbrown 0.15.4",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -35,24 +50,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.25.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65178f3df98a51e4238e584fcb255cb1a4f9111820848eeddd37663be40a625f"
+checksum = "d2d63dd5041e49c363d83f5419a896ecb074d309c414036f616dc0b04faca971"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown",
- "paste",
+ "hashbrown 0.15.4",
  "static_assertions",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.25.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d941bb8c414caba6e206de669c7dc0dbeb305640ea890772ee422a40e6b89f"
+checksum = "c8cfabe59d0eaca7412bfb1f70198dd31e3b0496fee7e15b066f9c36a1a140a0"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -66,6 +80,19 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -237,6 +264,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.0.8",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,30 +328,24 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8369c16b7c017437021341521f8b4a0d98e1c70113fb358c3258ae7d661d79"
+checksum = "1fd310426290cec560221f9750c2f4484be4a8eeea7de3483c423329b465c40e"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3561712cf49074d89e9989bfc2e6c6add5d33288f689db9a0c333300d2d004"
+checksum = "e887b25c84f384ffe3278a17cf0e4b405eaa3c8fbc3db24d05d560a11780676d"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -316,28 +355,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_animation"
-version = "0.16.1"
+name = "bevy_android"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49796627726d0b9a722ad9a0127719e7c1868f474d6575ec0f411e8299c4d7bb"
+checksum = "a8c58de772ac1148884112e8a456c4f127a94b95a0e42ab5b160b7a11895a241"
 dependencies = [
+ "android-activity",
+]
+
+[[package]]
+name = "bevy_animation"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5bf5b285f0d3fab983b4505e62e195e06930a29007ffc95bdabde834e163a2"
+dependencies = [
+ "bevy_animation_macros",
  "bevy_app",
  "bevy_asset",
  "bevy_color",
  "bevy_derive",
  "bevy_ecs",
- "bevy_log",
  "bevy_math",
  "bevy_mesh",
  "bevy_platform",
  "bevy_reflect",
- "bevy_render",
  "bevy_time",
  "bevy_transform",
  "bevy_utils",
  "blake3",
  "derive_more",
- "downcast-rs",
+ "downcast-rs 2.0.1",
  "either",
  "petgraph",
  "ron",
@@ -350,10 +397,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_app"
-version = "0.16.1"
+name = "bevy_animation_macros"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4491cc4c718ae76b4c6883df58b94cc88b32dcd894ea8d5b603c7c7da72ca967"
+checksum = "7cf35516d0e7ac9ec25df533be1bf8cbaa20596a8e65f36838a3f7803a267d6d"
+dependencies = [
+ "bevy_macro_utils",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bevy_anti_alias"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726cc494eb7d6a84ce6291c23636fd451fa4846604dc059fa93febca4e60a928"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_diagnostic",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_utils",
+ "tracing",
+]
+
+[[package]]
+name = "bevy_app"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def9f41aa5bf9b9dec8beda307a332798609cffb9d44f71005e0cfb45164f2f6"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -364,7 +444,7 @@ dependencies = [
  "cfg-if",
  "console_error_panic_hook",
  "ctrlc",
- "downcast-rs",
+ "downcast-rs 2.0.1",
  "log",
  "thiserror 2.0.12",
  "variadics_please",
@@ -374,33 +454,36 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56111d9b88d8649f331a667d9d72163fb26bd09518ca16476d238653823db1e"
+checksum = "29f86fed15972b9fb1a3f7b092cf0390e67131caaedab15a2707c043e3a3c886"
 dependencies = [
  "async-broadcast",
+ "async-channel",
  "async-fs",
+ "async-io",
  "async-lock",
  "atomicow",
+ "bevy_android",
  "bevy_app",
  "bevy_asset_macros",
+ "bevy_diagnostic",
  "bevy_ecs",
  "bevy_platform",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bevy_window",
  "bitflags 2.9.1",
  "blake3",
  "crossbeam-channel",
  "derive_more",
  "disqualified",
- "downcast-rs",
+ "downcast-rs 2.0.1",
  "either",
  "futures-io",
  "futures-lite",
+ "futures-util",
  "js-sys",
- "parking_lot",
  "ron",
  "serde",
  "stackfuture",
@@ -414,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cca3e67c0ec760d8889d42293d987ce5da92eaf9c592bf5d503728a63b276d"
+checksum = "12cb8d948365b06561b43b7d709282e62a6abb756baac5d8e295206d5e156168"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -426,27 +509,53 @@ dependencies = [
 
 [[package]]
 name = "bevy_audio"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b4f6f2a5c6c0e7c6825e791d2a061c76c2d6784f114c8f24382163fabbfaaa"
+checksum = "9d68da32468ce7f4bb2863b71326acfaaa88e9aef8da8306257cd487d40cede4"
 dependencies = [
  "bevy_app",
  "bevy_asset",
- "bevy_derive",
  "bevy_ecs",
  "bevy_math",
  "bevy_reflect",
  "bevy_transform",
+ "coreaudio-sys",
  "cpal",
  "rodio",
  "tracing",
 ]
 
 [[package]]
-name = "bevy_color"
-version = "0.16.2"
+name = "bevy_camera"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c101cbe1e26b8d701eb77263b14346e2e0cbbd2a6e254b9b1aead814e5ca8d3"
+checksum = "37ed9eed054e14341852236d06a7244597b1ace39ff9ae023fbd188ffde88619"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_reflect",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
+ "derive_more",
+ "downcast-rs 2.0.1",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.12",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_color"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb41e8310a85811d14a4e75cfc2d6c07ac70661d6a4883509fc960f622970a8"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -460,12 +569,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed46363cad80dc00f08254c3015232bd6f640738403961c6d63e7ecfc61625"
+checksum = "4d0810e85c2436e50c67448d48a83bf0bb1b5849899619ae2c7ea817221e9172"
 dependencies = [
  "bevy_app",
  "bevy_asset",
+ "bevy_camera",
  "bevy_color",
  "bevy_derive",
  "bevy_diagnostic",
@@ -475,14 +585,13 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_render",
+ "bevy_shader",
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
  "bitflags 2.9.1",
- "bytemuck",
  "nonmax",
  "radsort",
- "serde",
  "smallvec",
  "thiserror 2.0.12",
  "tracing",
@@ -490,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b837bf6c51806b10ebfa9edf1844ad80a3a0760d6c5fac4e90761df91a8901a"
+checksum = "318ee0532c3da93749859d18f89a889c638fbc56aabac4d866583df7b951d103"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -500,17 +609,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_diagnostic"
-version = "0.16.1"
+name = "bevy_dev_tools"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48797366f312a8f31e237d08ce3ee70162591282d2bfe7c5ad8be196fb263e55"
+checksum = "a4f1464a3f5ef5c23d917987714ee89881f9f791e9ff97ecf6600ee846b9569e"
 dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_diagnostic",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_input",
+ "bevy_math",
+ "bevy_picking",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_state",
+ "bevy_text",
+ "bevy_time",
+ "bevy_transform",
+ "bevy_ui",
+ "bevy_ui_render",
+ "bevy_window",
+ "tracing",
+]
+
+[[package]]
+name = "bevy_diagnostic"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8543a0f7afd56d3499ba80ffab6ef0bad12f93c2d2ca9aa7b1f1b8816c3980"
+dependencies = [
+ "atomic-waker",
  "bevy_app",
  "bevy_ecs",
  "bevy_platform",
  "bevy_tasks",
  "bevy_time",
- "bevy_utils",
  "const-fnv1a-hash",
  "log",
  "serde",
@@ -519,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2bf6521aae57a0ec3487c4bfb59e36c4a378e834b626a4bea6a885af2fdfe7"
+checksum = "c9cf7a3ee41342dd7b5a5d82e200d0e8efb933169247fce853b4ad633d51e87d"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -534,12 +672,12 @@ dependencies = [
  "bumpalo",
  "concurrent-queue",
  "derive_more",
- "disqualified",
  "fixedbitset",
  "indexmap",
  "log",
  "nonmax",
  "serde",
+ "slotmap",
  "smallvec",
  "thiserror 2.0.12",
  "variadics_please",
@@ -547,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38748d6f3339175c582d751f410fb60a93baf2286c3deb7efebb0878dce7f413"
+checksum = "908baf585e2ea16bd53ef0da57b69580478af0059d2dbdb4369991ac9794b618"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -559,12 +697,42 @@ dependencies = [
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8148f4edee470a2ea5cad010184c492a4c94c36d7a7158ea28e134ea87f274ab"
+checksum = "d4fee46eeddcbc00a805ae00ffa973f224671fc5cf0fe1a796963804faeade90"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
+]
+
+[[package]]
+name = "bevy_feathers"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cb29be8f8443c5cc44e1c4710bbe02877e73703c60228ca043f20529a5496c6"
+dependencies = [
+ "accesskit",
+ "bevy_a11y",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_input_focus",
+ "bevy_log",
+ "bevy_math",
+ "bevy_picking",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_text",
+ "bevy_ui",
+ "bevy_ui_render",
+ "bevy_ui_widgets",
+ "bevy_window",
+ "smol_str",
 ]
 
 [[package]]
@@ -575,6 +743,7 @@ dependencies = [
  "bevy",
  "bevy_app",
  "bevy_asset",
+ "bevy_camera",
  "bevy_color",
  "bevy_core_pipeline",
  "bevy_derive",
@@ -599,16 +768,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97efef87c631949e67d06bb5d7dfd2a5f936b3b379afb6b1485b08edbb219b87"
+checksum = "611827ab0ce43b88c0a695e6603901b5f34687efecaf526c861456c9d8e6fedb"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_input",
  "bevy_platform",
  "bevy_time",
- "bevy_utils",
  "gilrs",
  "thiserror 2.0.12",
  "tracing",
@@ -616,23 +784,54 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7823154a9682128c261d8bddb3a4d7192a188490075c527af04520c2f0f8aad6"
+checksum = "6aaff0dd5f405c83d290c5cd591835f1ae8009894947ab19dadcb323062bd7e7"
 dependencies = [
  "bevy_app",
  "bevy_asset",
+ "bevy_camera",
  "bevy_color",
- "bevy_core_pipeline",
  "bevy_ecs",
  "bevy_gizmos_macros",
+ "bevy_light",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_time",
+ "bevy_transform",
+ "bevy_utils",
+]
+
+[[package]]
+name = "bevy_gizmos_macros"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6960ea308d7e94adcac5c712553ff86614bba6b663511f3f3812f6bec028b51e"
+dependencies = [
+ "bevy_macro_utils",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bevy_gizmos_render"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a8d18c089102de4c5e9326023ad96ba618a6961029f8102a33640b966883237"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_core_pipeline",
+ "bevy_ecs",
+ "bevy_gizmos",
  "bevy_image",
  "bevy_math",
+ "bevy_mesh",
  "bevy_pbr",
- "bevy_reflect",
  "bevy_render",
- "bevy_sprite",
- "bevy_time",
+ "bevy_shader",
+ "bevy_sprite_render",
  "bevy_transform",
  "bevy_utils",
  "bytemuck",
@@ -640,31 +839,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_gizmos_macros"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f378f3b513218ddc78254bbe76536d9de59c1429ebd0c14f5d8f2a25812131ad"
-dependencies = [
- "bevy_macro_utils",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "bevy_gltf"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a080237c0b8842ccc15a06d3379302c68580eeea4497b1c7387e470eda1f07"
+checksum = "5f37fb52655d0439656ca0a1db027d46926e463c81d893d4b1639668e5d7f1c1"
 dependencies = [
- "base64 0.22.1",
+ "async-lock",
+ "base64",
  "bevy_animation",
  "bevy_app",
  "bevy_asset",
+ "bevy_camera",
  "bevy_color",
- "bevy_core_pipeline",
  "bevy_ecs",
  "bevy_image",
+ "bevy_light",
  "bevy_math",
  "bevy_mesh",
  "bevy_pbr",
@@ -674,7 +863,6 @@ dependencies = [
  "bevy_scene",
  "bevy_tasks",
  "bevy_transform",
- "bevy_utils",
  "fixedbitset",
  "gltf",
  "itertools 0.14.0",
@@ -688,13 +876,14 @@ dependencies = [
 
 [[package]]
 name = "bevy_image"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e6e900cfecadbc3149953169e36b9e26f922ed8b002d62339d8a9dc6129328"
+checksum = "a71daf9b2afdd032c2b1122d1d501f99126218cb3e9983b3604ec381daa35f22"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
+ "bevy_ecs",
  "bevy_math",
  "bevy_platform",
  "bevy_reflect",
@@ -716,16 +905,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d6b6516433f6f7d680f648d04eb1866bb3927a1782d52f74831b62042f3cd1"
+checksum = "dbc8ffbd02df34dfc52faf420a5263985973765e228043adf542fd0d790a6b21"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_math",
  "bevy_platform",
  "bevy_reflect",
- "bevy_utils",
  "derive_more",
  "log",
  "smol_str",
@@ -734,14 +922,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_input_focus"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2d079fda74d1416e0a57dac29ea2b79ff77f420cd6b87f833d3aa29a46bc4d"
+checksum = "08d48a5bceccb9157549a39ab3de4017f5368b65db6471605e9a3f1c19d91bbc"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_input",
  "bevy_math",
+ "bevy_picking",
  "bevy_reflect",
  "bevy_window",
  "log",
@@ -750,56 +939,90 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857da8785678fde537d02944cd20dec9cafb7d4c447efe15f898dc60e733cacd"
+checksum = "6a11df62e49897def470471551c02f13c6fb488e55dddb5ab7ef098132e07754"
 dependencies = [
  "bevy_a11y",
+ "bevy_android",
  "bevy_animation",
+ "bevy_anti_alias",
  "bevy_app",
  "bevy_asset",
  "bevy_audio",
+ "bevy_camera",
  "bevy_color",
  "bevy_core_pipeline",
  "bevy_derive",
+ "bevy_dev_tools",
  "bevy_diagnostic",
  "bevy_ecs",
+ "bevy_feathers",
  "bevy_gilrs",
  "bevy_gizmos",
+ "bevy_gizmos_render",
  "bevy_gltf",
  "bevy_image",
  "bevy_input",
  "bevy_input_focus",
+ "bevy_light",
  "bevy_log",
  "bevy_math",
+ "bevy_mesh",
  "bevy_pbr",
  "bevy_picking",
  "bevy_platform",
+ "bevy_post_process",
  "bevy_ptr",
  "bevy_reflect",
  "bevy_render",
  "bevy_scene",
+ "bevy_shader",
  "bevy_sprite",
+ "bevy_sprite_render",
  "bevy_state",
  "bevy_tasks",
  "bevy_text",
  "bevy_time",
  "bevy_transform",
  "bevy_ui",
+ "bevy_ui_render",
  "bevy_utils",
  "bevy_window",
  "bevy_winit",
 ]
 
 [[package]]
-name = "bevy_log"
-version = "0.16.1"
+name = "bevy_light"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a61ee8aef17a974f5ca481dcedf0c2bd52670e231d4c4bc9ddef58328865f9"
+checksum = "4d9d2ac64390a9baacb3c0fa0f5456ac1553959d5a387874c102a09aab8b92cc"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_transform",
+ "bevy_utils",
+ "tracing",
+]
+
+[[package]]
+name = "bevy_log"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2aac1187f83a1ab2eae887564f7fb14b4abb3fbe8b2267a6426663463923120"
 dependencies = [
  "android_log-sys",
  "bevy_app",
  "bevy_ecs",
+ "bevy_platform",
  "bevy_utils",
  "tracing",
  "tracing-log",
@@ -810,24 +1033,24 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052eeebcb8e7e072beea5031b227d9a290f8a7fbbb947573ab6ec81df0fb94be"
+checksum = "3b147843b81a7ec548876ff97fa7bfdc646ef2567cb465566259237b39664438"
 dependencies = [
- "parking_lot",
  "proc-macro2",
  "quote",
  "syn",
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
 name = "bevy_math"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68553e0090fe9c3ba066c65629f636bd58e4ebd9444fdba097b91af6cd3e243f"
+checksum = "e931fa969f89c83498b22c97432383afe90e90fd1a5e04fa07be8da4d3bcac84"
 dependencies = [
  "approx",
+ "arrayvec",
  "bevy_reflect",
  "derive_more",
  "glam",
@@ -836,17 +1059,17 @@ dependencies = [
  "rand",
  "rand_distr",
  "serde",
- "smallvec",
  "thiserror 2.0.12",
  "variadics_please",
 ]
 
 [[package]]
 name = "bevy_mesh"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10399c7027001edbc0406d7d0198596b1f07206c1aae715274106ba5bdcac40"
+checksum = "288f590c8173d4cca3cae5f2ba579accd5ed1a35dd3fab338f427eb39d55f05e"
 dependencies = [
+ "bevy_app",
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
@@ -856,11 +1079,10 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_transform",
- "bevy_utils",
  "bitflags 2.9.1",
  "bytemuck",
+ "derive_more",
  "hexasphere",
- "serde",
  "thiserror 2.0.12",
  "tracing",
  "wgpu-types",
@@ -868,41 +1090,41 @@ dependencies = [
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.16.1"
+version = "0.17.0-dev"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb60c753b968a2de0fd279b76a3d19517695e771edb4c23575c7f92156315de"
-dependencies = [
- "glam",
-]
+checksum = "7ef8e4b7e61dfe7719bb03c884dc270cd46a82efb40f93e9933b990c5c190c59"
 
 [[package]]
 name = "bevy_pbr"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5e0b4eb871f364a0d217f70f6c41d7fdc6f9f931fa1abbf222180c03d0ae410"
+checksum = "a5ab6944ffc6fd71604c0fbca68cc3e2a3654edfcdbfd232f9d8b88e3d20fdc0"
 dependencies = [
  "bevy_app",
  "bevy_asset",
+ "bevy_camera",
  "bevy_color",
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_diagnostic",
  "bevy_ecs",
  "bevy_image",
+ "bevy_light",
+ "bevy_log",
  "bevy_math",
+ "bevy_mesh",
  "bevy_platform",
  "bevy_reflect",
  "bevy_render",
+ "bevy_shader",
  "bevy_transform",
  "bevy_utils",
- "bevy_window",
  "bitflags 2.9.1",
  "bytemuck",
  "derive_more",
  "fixedbitset",
  "nonmax",
  "offset-allocator",
- "radsort",
  "smallvec",
  "static_assertions",
  "thiserror 2.0.12",
@@ -911,12 +1133,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_picking"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed04757938655ed8094ea1efb533f99063a8b22abffc22010c694d291522850"
+checksum = "b7d524dbc8f2c9e73f7ab70c148c8f7886f3c24b8aa8c252a38ba68ed06cbf10"
 dependencies = [
  "bevy_app",
  "bevy_asset",
+ "bevy_camera",
  "bevy_derive",
  "bevy_ecs",
  "bevy_input",
@@ -924,10 +1147,8 @@ dependencies = [
  "bevy_mesh",
  "bevy_platform",
  "bevy_reflect",
- "bevy_render",
  "bevy_time",
  "bevy_transform",
- "bevy_utils",
  "bevy_window",
  "crossbeam-channel",
  "tracing",
@@ -936,33 +1157,65 @@ dependencies = [
 
 [[package]]
 name = "bevy_platform"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7573dc824a1b08b4c93fdbe421c53e1e8188e9ca1dd74a414455fe571facb47"
+checksum = "ec6b36504169b644acd26a5469fd8d371aa6f1d73ee5c01b1b1181ae1cefbf9b"
 dependencies = [
- "cfg-if",
  "critical-section",
- "foldhash",
- "getrandom 0.2.16",
- "hashbrown",
+ "foldhash 0.2.0",
+ "futures-channel",
+ "hashbrown 0.16.1",
+ "js-sys",
  "portable-atomic",
  "portable-atomic-util",
  "serde",
  "spin",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-time",
 ]
 
 [[package]]
-name = "bevy_ptr"
-version = "0.16.1"
+name = "bevy_post_process"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7370d0e46b60e071917711d0860721f5347bc958bf325975ae6913a5dfcf01"
+checksum = "8f77a4e894aea992e3d6938f1d5898a1cdbb87dba6eebfb95cb4038d0a2600e9"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_math",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
+ "bitflags 2.9.1",
+ "nonmax",
+ "radsort",
+ "smallvec",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "bevy_ptr"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a9329e8dc4e01ced480eeec4902e6d7cb56e56ec37f6fbc4323e5c937290a7"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daeb91a63a1a4df00aa58da8cc4ddbd4b9f16ab8bb647c5553eb156ce36fa8c2"
+checksum = "d1dfeb67a9fe4f59003a84f5f99ba6302141c70e926601cbc6abfd4a1eea9ca9"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -971,10 +1224,12 @@ dependencies = [
  "bevy_utils",
  "derive_more",
  "disqualified",
- "downcast-rs",
+ "downcast-rs 2.0.1",
  "erased-serde",
- "foldhash",
+ "foldhash 0.2.0",
  "glam",
+ "indexmap",
+ "inventory",
  "petgraph",
  "serde",
  "smallvec",
@@ -987,11 +1242,12 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ddadc55fe16b45faaa54ab2f9cb00548013c74812e8b018aa172387103cce6"
+checksum = "475f68c93e9cd5f17e9167635c8533a4f388f12d38245a202359e4c2721d87ba"
 dependencies = [
  "bevy_macro_utils",
+ "indexmap",
  "proc-macro2",
  "quote",
  "syn",
@@ -1000,13 +1256,14 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef91fed1f09405769214b99ebe4390d69c1af5cdd27967deae9135c550eb1667"
+checksum = "243523e33fe5dfcebc4240b1eb2fc16e855c5d4c0ea6a8393910740956770f44"
 dependencies = [
  "async-channel",
  "bevy_app",
  "bevy_asset",
+ "bevy_camera",
  "bevy_color",
  "bevy_derive",
  "bevy_diagnostic",
@@ -1018,6 +1275,7 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_render_macros",
+ "bevy_shader",
  "bevy_tasks",
  "bevy_time",
  "bevy_transform",
@@ -1025,22 +1283,18 @@ dependencies = [
  "bevy_window",
  "bitflags 2.9.1",
  "bytemuck",
- "codespan-reporting",
  "derive_more",
- "downcast-rs",
+ "downcast-rs 2.0.1",
  "encase",
  "fixedbitset",
- "futures-lite",
+ "glam",
  "image",
  "indexmap",
  "js-sys",
- "ktx2",
  "naga",
- "naga_oil",
  "nonmax",
  "offset-allocator",
  "send_wrapper",
- "serde",
  "smallvec",
  "thiserror 2.0.12",
  "tracing",
@@ -1052,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd42cf6c875bcf38da859f8e731e119a6aff190d41dd0a1b6000ad57cf2ed3d"
+checksum = "66b6325e9c495a71270446784611e8d7f446f927eac8506c4c099fd10cb4c3ed"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1064,60 +1318,105 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c52ca165200995fe8afd2a1a6c03e4ffee49198a1d4653d32240ea7f217d4ab"
+checksum = "34cc1047d85ec8048261b63ef675c12f1e6b5782dc0b422fbcee0c140d026bd4"
 dependencies = [
  "bevy_app",
  "bevy_asset",
+ "bevy_camera",
  "bevy_derive",
  "bevy_ecs",
  "bevy_platform",
  "bevy_reflect",
- "bevy_render",
  "bevy_transform",
  "bevy_utils",
  "derive_more",
+ "ron",
  "serde",
  "thiserror 2.0.12",
  "uuid",
 ]
 
 [[package]]
-name = "bevy_sprite"
-version = "0.16.1"
+name = "bevy_shader"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ccae7bab2cb956fb0434004c359e432a3a1a074a6ef4eb471f1fb099f0b620b"
+checksum = "9eea95f0273c32be13d6a0b799a93bc256ad7830759ede595c404d5234302da2"
+dependencies = [
+ "bevy_asset",
+ "bevy_platform",
+ "bevy_reflect",
+ "naga",
+ "naga_oil",
+ "serde",
+ "thiserror 2.0.12",
+ "tracing",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_sprite"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ec5bc0cbdee551b610a46f41d30374bbe42b8951ffc676253c6243ab2b9395"
 dependencies = [
  "bevy_app",
  "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_picking",
+ "bevy_reflect",
+ "bevy_text",
+ "bevy_transform",
+ "bevy_window",
+ "radsort",
+ "tracing",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_sprite_render"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b82cb08905e7ddcea2694a95f757ae7f1fd01e6a7304076bad595d2158e4bfe0"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
  "bevy_color",
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
- "bevy_picking",
+ "bevy_mesh",
  "bevy_platform",
  "bevy_reflect",
  "bevy_render",
+ "bevy_shader",
+ "bevy_sprite",
+ "bevy_text",
  "bevy_transform",
  "bevy_utils",
- "bevy_window",
  "bitflags 2.9.1",
  "bytemuck",
  "derive_more",
  "fixedbitset",
  "nonmax",
- "radsort",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_state"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155d3cd97b900539008cdcaa702f88b724d94b08977b8e591a32536ce66faa8c"
+checksum = "0ae0682968e97d29c1eccc8c6bb6283f2678d362779bc03f1bb990967059473b"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1131,43 +1430,39 @@ dependencies = [
 
 [[package]]
 name = "bevy_state_macros"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2481c1304fd2a1851a0d4cb63a1ce6421ae40f3f0117cbc9882963ee4c9bb609"
+checksum = "73d32f90f9cfcef5a44401db7ce206770daaa1707b0fb95eb7a96a6933f54f1b"
 dependencies = [
  "bevy_macro_utils",
- "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "bevy_tasks"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b674242641cab680688fc3b850243b351c1af49d4f3417a576debd6cca8dcf5"
+checksum = "384eb04d80aa38664d69988fd30cbbe03e937ecb65c66aa6abe60ce0bca826aa"
 dependencies = [
  "async-channel",
  "async-executor",
  "async-task",
  "atomic-waker",
  "bevy_platform",
- "cfg-if",
  "concurrent-queue",
  "crossbeam-queue",
  "derive_more",
- "futures-channel",
  "futures-lite",
  "heapless",
  "pin-project",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "bevy_text"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d76c85366159f5f54110f33321c76d8429cfd8f39638f26793a305dae568b60"
+checksum = "fdc5233291dfc22e584de2535f2e37ae9766d37cb5a01652de2133ba202dcb9b"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1179,25 +1474,21 @@ dependencies = [
  "bevy_math",
  "bevy_platform",
  "bevy_reflect",
- "bevy_render",
- "bevy_sprite",
- "bevy_transform",
  "bevy_utils",
- "bevy_window",
  "cosmic-text",
  "serde",
  "smallvec",
  "sys-locale",
  "thiserror 2.0.12",
  "tracing",
- "unicode-bidi",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_time"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc98eb356c75be04fbbc77bb3d8ffa24c8bacd99f76111cee23d444be6ac8c9c"
+checksum = "b5ef9af4e523195e561074cf60fbfad0f4cb8d1db504855fee3c4ce8896c7244"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1210,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df218e440bb9a19058e1b80a68a031c887bcf7bd3a145b55f361359a2fa3100d"
+checksum = "3c3bb3de7842fef699344beb03f22bdbff16599d788fe0f47fbb3b1e6fa320eb"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1228,79 +1519,130 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a4d2ba51865bc3039af29a26b4f52c48b54cc758369f52004caf4b6f03770"
+checksum = "1691a411014085e0d35f8bb8208e5f973edd7ace061a4b1c41c83de21579dc70"
 dependencies = [
  "accesskit",
  "bevy_a11y",
  "bevy_app",
  "bevy_asset",
+ "bevy_camera",
  "bevy_color",
- "bevy_core_pipeline",
  "bevy_derive",
  "bevy_ecs",
  "bevy_image",
  "bevy_input",
+ "bevy_input_focus",
  "bevy_math",
  "bevy_picking",
  "bevy_platform",
  "bevy_reflect",
- "bevy_render",
  "bevy_sprite",
  "bevy_text",
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bytemuck",
  "derive_more",
- "nonmax",
  "smallvec",
  "taffy",
  "thiserror 2.0.12",
  "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "bevy_ui_render"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2c35402d8a052f512e3fec1f36b26e83eee713fcca57f965c244ee795e1fcb0"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_sprite",
+ "bevy_sprite_render",
+ "bevy_text",
+ "bevy_transform",
+ "bevy_ui",
+ "bevy_utils",
+ "bytemuck",
+ "derive_more",
+ "tracing",
+]
+
+[[package]]
+name = "bevy_ui_widgets"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a63cb818b0de41bdb14990e0ce1aaaa347f871750ab280f80c427e83d72712"
+dependencies = [
+ "accesskit",
+ "bevy_a11y",
+ "bevy_app",
+ "bevy_camera",
+ "bevy_ecs",
+ "bevy_input",
+ "bevy_input_focus",
+ "bevy_log",
+ "bevy_math",
+ "bevy_picking",
+ "bevy_reflect",
+ "bevy_ui",
 ]
 
 [[package]]
 name = "bevy_utils"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f7a8905a125d2017e8561beefb7f2f5e67e93ff6324f072ad87c5fd6ec3b99"
+checksum = "2111910cd7a4b1e6ce07eaaeb6f68a2c0ea0ca609ed0d0d506e3eb161101435b"
 dependencies = [
  "bevy_platform",
+ "disqualified",
  "thread_local",
 ]
 
 [[package]]
 name = "bevy_window"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7e8ad0c17c3cc23ff5566ae2905c255e6986037fb041f74c446216f5c38431"
+checksum = "6df06e6993a0896bae2fe7644ae6def29a1a92b45dfb1bcebbd92af782be3638"
 dependencies = [
- "android-activity",
  "bevy_app",
+ "bevy_asset",
  "bevy_ecs",
+ "bevy_image",
  "bevy_input",
  "bevy_math",
  "bevy_platform",
  "bevy_reflect",
- "bevy_utils",
  "log",
  "raw-window-handle",
  "serde",
- "smol_str",
 ]
 
 [[package]]
 name = "bevy_winit"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5e7f00c6b3b6823df5ec2a5e9067273607208919bc8c211773ebb9643c87f0"
+checksum = "f2de1c13d32ab8528435b58eca7ab874a1068184c6d6f266ee11433ae99d4069"
 dependencies = [
  "accesskit",
  "accesskit_winit",
  "approx",
  "bevy_a11y",
+ "bevy_android",
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
@@ -1313,12 +1655,10 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_tasks",
- "bevy_utils",
  "bevy_window",
  "bytemuck",
  "cfg-if",
- "crossbeam-channel",
- "raw-window-handle",
+ "js-sys",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -1348,26 +1688,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.9.1",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
@@ -1386,27 +1706,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1426,6 +1731,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
+ "bytemuck",
  "serde",
 ]
 
@@ -1529,6 +1835,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,10 +1897,11 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
  "unicode-width",
 ]
@@ -1651,6 +1970,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,7 +2012,7 @@ checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "core-graphics-types",
+ "core-graphics-types 0.1.3",
  "foreign-types",
  "libc",
 ]
@@ -1698,6 +2026,26 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
+ "libc",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -1717,26 +2065,27 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
 dependencies = [
- "bindgen 0.72.0",
+ "bindgen",
 ]
 
 [[package]]
 name = "cosmic-text"
-version = "0.13.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e418dd4f5128c3e93eab12246391c54a20c496811131f85754dc8152ee207892"
+checksum = "c4cadaea21e24c49c0c82116f2b465ae6a49d63c90e428b0f8d9ae1f638ac91f"
 dependencies = [
  "bitflags 2.9.1",
  "fontdb",
+ "harfrust",
+ "linebender_resource_handle",
  "log",
  "rangemap",
  "rustc-hash 1.1.0",
- "rustybuzz",
  "self_cell",
+ "skrifa 0.39.0",
  "smol_str",
  "swash",
  "sys-locale",
- "ttf-parser 0.21.1",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-script",
@@ -1841,21 +2190,23 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
  "unicode-xid",
 ]
@@ -1892,6 +2243,12 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "downcast-rs"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
@@ -1910,30 +2267,29 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encase"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a05902cf601ed11d564128448097b98ebe3c6574bd7b6a653a3d56d54aa020"
+checksum = "6e3e0ff2ee0b7aa97428308dd9e1e42369cb22f5fb8dc1c55546637443a60f1e"
 dependencies = [
  "const_panic",
  "encase_derive",
- "glam",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "encase_derive"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "181d475b694e2dd56ae919ce7699d344d1fd259292d590c723a50d1189a2ea85"
+checksum = "a4d90c5d7d527c6cb8a3b114efd26a6304d9ab772656e73d8f4e32b1f3d601a2"
 dependencies = [
  "encase_derive_impl",
 ]
 
 [[package]]
 name = "encase_derive_impl"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97b51c5cc57ef7c5f7a0c57c250251c49ee4c28f819f87ac32f4aceabc36792"
+checksum = "c8bad72d8308f7a382de2391ec978ddd736e0103846b965d7e2a63a75768af30"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2040,10 +2396,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "font-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a596f5713680923a2080d86de50fe472fb290693cf0f701187a1c8b36996b7"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "font-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
 dependencies = [
  "bytemuck",
 ]
@@ -2059,16 +2430,16 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.16.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
 dependencies = [
  "fontconfig-parser",
  "log",
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser 0.20.0",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -2109,9 +2480,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
@@ -2133,6 +2504,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,19 +2545,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -2164,7 +2552,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi",
 ]
 
 [[package]]
@@ -2214,14 +2602,15 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.29.3"
+version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
 dependencies = [
  "bytemuck",
+ "encase",
  "libm",
  "rand",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2326,7 +2715,7 @@ checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
  "bitflags 2.9.1",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -2340,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "0.15.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36119f3a540b086b4e436bb2b588cf98a68863470e0e880f4d0842f112a3183a"
+checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
 
 [[package]]
 name = "guillotiere"
@@ -2362,6 +2751,20 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0caaee032384c10dd597af4579c67dee16650d862a9ccbe1233ff1a379abc07"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytemuck",
+ "core_maths",
+ "read-fonts 0.36.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -2379,27 +2782,31 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
  "hash32",
  "portable-atomic",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2409,9 +2816,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hexasphere"
-version = "15.1.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c9e718d32b6e6b2b32354e1b0367025efdd0b11d6a740b905ddf5db1074679"
+checksum = "29a164ceff4500f2a72b1d21beaa8aa8ad83aec2b641844c659b190cb3ea2e0b"
 dependencies = [
  "constgebra",
  "glam",
@@ -2437,23 +2844,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "immutable-chunkmap"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f97096f508d54f8f8ab8957862eee2ccd628847b6217af1a335e1c44dee578"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2480,6 +2879,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2544,15 +2952,15 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2577,11 +2985,11 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "ktx2"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d65e08a9ec02e409d27a0139eaa6b9756b4d81fe7cde71f6941a83730ce838"
+checksum = "ff7f53bdf698e7aa7ec916411bbdc8078135da11b66db5182675b2227f6c0d07"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2643,6 +3051,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2717,11 +3131,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2741,13 +3155,13 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
+checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
  "bitflags 2.9.1",
  "block",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types",
  "log",
  "objc",
@@ -2772,43 +3186,44 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "24.0.0"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
+checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
- "bit-set 0.8.0",
+ "bit-set",
  "bitflags 2.9.1",
+ "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
  "hexf-parse",
  "indexmap",
+ "libm",
  "log",
+ "num-traits",
+ "once_cell",
  "pp-rs",
  "rustc-hash 1.1.0",
  "spirv",
- "strum",
- "termcolor",
  "thiserror 2.0.12",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "naga_oil"
-version = "0.17.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2464f7395decfd16bb4c33fb0cb3b2c645cc60d051bc7fb652d3720bfb20f18"
+checksum = "310c347db1b30e69581f3b84dc9a5c311ed583f67851b39b77953cb7a066c97f"
 dependencies = [
- "bit-set 0.5.3",
  "codespan-reporting",
  "data-encoding",
  "indexmap",
  "naga",
- "once_cell",
  "regex",
- "regex-syntax 0.8.5",
  "rustc-hash 1.1.0",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
  "unicode-ident",
 ]
@@ -2917,12 +3332,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3098,6 +3512,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-link-presentation"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,10 +3680,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
+name = "owned_ttf_parser"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
+]
 
 [[package]]
 name = "parking"
@@ -3304,11 +3731,12 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.4",
  "indexmap",
  "serde",
  "serde_derive",
@@ -3424,22 +3852,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3456,6 +3874,15 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -3480,20 +3907,19 @@ checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -3501,18 +3927,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom",
 ]
 
 [[package]]
 name = "rand_distr"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand",
@@ -3543,7 +3969,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04ca636dac446b5664bd16c069c00a9621806895b8bb02c2dc68542b23b8f25d"
 dependencies = [
  "bytemuck",
- "font-types",
+ "font-types 0.9.0",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eaa2941a4c05443ee3a7b26ab076a553c343ad5995230cc2b1d3e993bdc6345"
+dependencies = [
+ "bytemuck",
+ "core_maths",
+ "font-types 0.10.1",
 ]
 
 [[package]]
@@ -3578,17 +4015,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3599,14 +4027,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3654,14 +4076,16 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.8.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
 dependencies = [
- "base64 0.21.7",
  "bitflags 2.9.1",
+ "once_cell",
  "serde",
  "serde_derive",
+ "typeid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3681,6 +4105,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -3715,23 +4148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
-name = "rustybuzz"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
-dependencies = [
- "bitflags 2.9.1",
- "bytemuck",
- "libm",
- "smallvec",
- "ttf-parser 0.21.1",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
-]
-
-[[package]]
 name = "ruzstd"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3756,16 +4172,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit",
+ "tiny-skia",
+]
+
+[[package]]
 name = "self_cell"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "send_wrapper"
@@ -3775,18 +4216,28 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3833,7 +4284,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbeb4ca4399663735553a09dd17ce7e49a0a0203f03b706b39628c4d913a8607"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.29.3",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9eb0b904a04d09bd68c65d946617b8ff733009999050f3b851c32fb3cfb60e"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.36.0",
 ]
 
 [[package]]
@@ -3858,6 +4319,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.9.1",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
 name = "smol_str"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3868,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "portable-atomic",
 ]
@@ -3903,26 +4389,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strum"
-version = "0.26.3"
+name = "strict-num"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "svg_fmt"
@@ -3936,16 +4406,16 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f745de914febc7c9ab4388dfaf94bbc87e69f57bb41133a9b0c84d4be49856f3"
 dependencies = [
- "skrifa",
+ "skrifa 0.31.3",
  "yazi",
  "zeno",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3963,22 +4433,23 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.34.2"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
- "windows 0.57.0",
+ "objc2-io-kit",
+ "windows 0.61.3",
 ]
 
 [[package]]
 name = "taffy"
-version = "0.7.7"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4f4d046dd956a47a7e1a2947083d7ac3e6aa3cfaaead36173ceaa5ab11878c"
+checksum = "41ba83ebaf2954d31d05d67340fd46cebe99da2b7133b0dd68d70c65473a437b"
 dependencies = [
  "arrayvec",
  "grid",
@@ -4045,6 +4516,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4066,21 +4562,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.11",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.10+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+dependencies = [
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4089,9 +4615,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4100,9 +4626,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4121,29 +4647,26 @@ dependencies = [
 
 [[package]]
 name = "tracing-oslog"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528bdd1f0e27b5dd9a4ededf154e824b0532731e4af73bb531de46276e0aab1e"
+checksum = "d76902d2a8d5f9f55a81155c08971734071968c90f2d9bfe645fe700579b2950"
 dependencies = [
- "bindgen 0.70.1",
  "cc",
  "cfg-if",
- "once_cell",
- "parking_lot",
  "tracing-core",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -4165,15 +4688,12 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.20.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
-
-[[package]]
-name = "ttf-parser"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "twox-hash"
@@ -4194,18 +4714,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
-name = "unicode-bidi-mirroring"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4216,12 +4724,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-script"
@@ -4259,7 +4761,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -4312,12 +4814,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
 version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
@@ -4327,37 +4823,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -4366,9 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4376,31 +4860,139 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wayland-backend"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+dependencies = [
+ "cc",
+ "downcast-rs 1.2.1",
+ "rustix 1.0.8",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+dependencies = [
+ "bitflags 2.9.1",
+ "rustix 1.0.8",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.9.1",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5864c4b5b6064b06b1e8b74ead4a98a6c45a285fe7a0e784d24735f011fdb078"
+dependencies = [
+ "rustix 1.0.8",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+dependencies = [
+ "bitflags 2.9.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa98634619300a535a9a97f338aed9a5ff1e01a461943e8346ff4ae26007306b"
+dependencies = [
+ "bitflags 2.9.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9597cdf02cf0c34cd5823786dce6b5ae8598f05c2daf5621b6e178d4f7345f3"
+dependencies = [
+ "bitflags 2.9.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4418,24 +5010,25 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "24.0.5"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
+checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
+ "cfg-if",
  "cfg_aliases",
  "document-features",
+ "hashbrown 0.16.1",
  "js-sys",
  "log",
  "naga",
- "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "smallvec",
  "static_assertions",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
  "wgpu-core",
  "wgpu-hal",
@@ -4444,49 +5037,85 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "24.0.5"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
+checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
 dependencies = [
  "arrayvec",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.9.1",
+ "bytemuck",
  "cfg_aliases",
  "document-features",
+ "hashbrown 0.16.1",
  "indexmap",
  "log",
  "naga",
  "once_cell",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.12",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-wasm",
+ "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
-name = "wgpu-hal"
-version = "24.0.4"
+name = "wgpu-core-deps-apple"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
+checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1027dcf3b027a877e44819df7ceb0e2e98578830f8cd34cd6c3c7c2a7a50b7"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "27.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set 0.8.0",
+ "bit-set",
  "bitflags 2.9.1",
  "block",
  "bytemuck",
+ "cfg-if",
  "cfg_aliases",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
+ "hashbrown 0.16.1",
  "js-sys",
  "khronos-egl",
  "libc",
@@ -4494,16 +5123,17 @@ dependencies = [
  "log",
  "metal",
  "naga",
- "ndk-sys 0.5.0+25.2.9519653",
+ "ndk-sys 0.6.0+11769913",
  "objc",
  "once_cell",
  "ordered-float",
  "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
  "profiling",
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
- "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.12",
  "wasm-bindgen",
@@ -4515,14 +5145,16 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "24.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
+checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
  "bitflags 2.9.1",
+ "bytemuck",
  "js-sys",
  "log",
  "serde",
+ "thiserror 2.0.12",
  "web-sys",
 ]
 
@@ -4569,16 +5201,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -4596,7 +5218,7 @@ dependencies = [
  "windows-collections",
  "windows-core 0.61.2",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -4615,18 +5237,6 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
@@ -4652,7 +5262,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface 0.59.1",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
 ]
@@ -4664,19 +5274,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4695,17 +5294,6 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4741,13 +5329,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4774,7 +5368,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4793,7 +5387,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4830,6 +5424,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4900,7 +5503,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5089,6 +5692,7 @@ version = "0.30.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4409c10174df8779dc29a4788cac85ed84024ccbc1743b776b21a520ee1aaf4"
 dependencies = [
+ "ahash",
  "android-activity",
  "atomic-waker",
  "bitflags 2.9.1",
@@ -5103,6 +5707,7 @@ dependencies = [
  "dpi",
  "js-sys",
  "libc",
+ "memmap2",
  "ndk 0.9.0",
  "objc2",
  "objc2-app-kit",
@@ -5114,11 +5719,17 @@ dependencies = [
  "raw-window-handle",
  "redox_syscall 0.4.1",
  "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit",
  "smol_str",
  "tracing",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
  "web-sys",
  "web-time",
  "windows-sys 0.52.0",
@@ -5129,12 +5740,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -5176,6 +5793,12 @@ name = "x11rb-protocol"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
 name = "xkbcommon-dl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,20 +13,21 @@ categories = ["game-development"]
 readme = "README.md"
 
 [dependencies]
-bevy_app = { version = "0.16" }
-bevy_asset = { version = "0.16" }
-bevy_core_pipeline = { version = "0.16" }
-bevy_color = { version = "0.16" }
-bevy_derive = { version = "0.16" }
-bevy_image = { version = "0.16" }
-bevy_ecs = { version = "0.16" }
-bevy_log = { version = "0.16" }
-bevy_math = { version = "0.16" }
-bevy_platform = { version = "0.16" }
-bevy_reflect = { version = "0.16" }
-bevy_render = { version = "0.16" }
-bevy_time = { version = "0.16" }
-bevy_transform = { version = "0.16" }
+bevy_app = { version = "0.18" }
+bevy_asset = { version = "0.18" }
+bevy_core_pipeline = { version = "0.18" }
+bevy_color = { version = "0.18" }
+bevy_derive = { version = "0.18" }
+bevy_image = { version = "0.18" }
+bevy_ecs = { version = "0.18" }
+bevy_log = { version = "0.18" }
+bevy_math = { version = "0.18" }
+bevy_platform = { version = "0.18" }
+bevy_reflect = { version = "0.18" }
+bevy_render = { version = "0.18" }
+bevy_camera = { version = "0.18" }
+bevy_time = { version = "0.18" }
+bevy_transform = { version = "0.18" }
 
 
 
@@ -56,7 +57,7 @@ format-bincode = ["bincode"]
 all-formats = ["format-json", "format-messagepack", "format-bincode", "all-compression"]
 
 [dev-dependencies]
-bevy = { version = "0.16" }
+bevy = { version = "0.18" }
 #bevy-inspector-egui = { version = "0.31" }
 
 

--- a/examples/simple_2d.rs
+++ b/examples/simple_2d.rs
@@ -161,8 +161,8 @@ fn camera_movement(
 /// 监听雾效重置事件的系统
 /// System that listens to fog reset events
 fn handle_fog_reset_events(
-    mut success_events: EventReader<FogResetSuccess>,
-    mut failure_events: EventReader<FogResetFailed>,
+    mut success_events: MessageReader<FogResetSuccess>,
+    mut failure_events: MessageReader<FogResetFailed>,
 ) {
     for event in success_events.read() {
         info!(
@@ -184,8 +184,8 @@ fn handle_fog_reset_events(
 fn handle_save_load_input(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut commands: Commands,
-    mut save_events: EventWriter<SaveFogOfWarRequest>,
-    mut load_events: EventWriter<LoadFogOfWarRequest>,
+    mut save_events: MessageWriter<SaveFogOfWarRequest>,
+    mut load_events: MessageWriter<LoadFogOfWarRequest>,
     capturable_entities: Query<Entity, With<Capturable>>,
 ) {
     // F5键 - 保存雾效数据
@@ -252,7 +252,7 @@ fn handle_save_load_input(
 
 /// 处理保存完成事件（演示多格式保存）
 /// Handle save completion event (demonstrate multi-format saving)
-fn handle_saved_event(mut events: EventReader<FogOfWarSaved>) {
+fn handle_saved_event(mut events: MessageReader<FogOfWarSaved>) {
     for event in events.read() {
         // 直接使用序列化后的二进制数据
         // Use the serialized binary data directly
@@ -290,7 +290,7 @@ fn handle_saved_event(mut events: EventReader<FogOfWarSaved>) {
 
 /// 处理加载完成事件
 /// Handle load completion event
-fn handle_loaded_event(mut events: EventReader<FogOfWarLoaded>) {
+fn handle_loaded_event(mut events: MessageReader<FogOfWarLoaded>) {
     for event in events.read() {
         info!("✅ Successfully loaded {} chunks", event.chunk_count);
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -588,7 +588,7 @@ impl FogChunkImage {
     /// ```
     pub fn from_setting_raw(images: &mut Assets<Image>, setting: &FogMapSettings) -> Self {
         // Create fog texture with zero-filled initial data
-        let data = vec![0u8; setting.fog_texture_format.pixel_size()];
+        let data = vec![0u8; setting.fog_texture_format.pixel_size().unwrap_or(0)];
         let mut fog_image = Image::new_fill(
             Extent3d {
                 width: setting.texture_resolution_per_chunk.x,
@@ -608,7 +608,7 @@ impl FogChunkImage {
         let fog_image_handle = images.add(fog_image);
 
         // Create snapshot texture with identical configuration
-        let data = vec![0u8; setting.snapshot_texture_format.pixel_size()];
+        let data = vec![0u8; setting.snapshot_texture_format.pixel_size().unwrap_or(0)];
         let mut snapshot_image = Image::new_fill(
             Extent3d {
                 width: setting.texture_resolution_per_chunk.x,

--- a/src/data_transfer.rs
+++ b/src/data_transfer.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use bevy_asset::Handle;
-use bevy_ecs::event::Event;
+
 use bevy_image::Image;
 use bevy_math::IVec2;
 use bevy_reflect::Reflect;
@@ -265,7 +265,7 @@ pub struct CpuToGpuCopyRequest {
 /// # use bevy_fog_of_war::prelude::*;
 /// # use bevy::prelude::*;
 /// fn handle_gpu_data_ready(
-///     mut events: EventReader<ChunkGpuDataReady>,
+///     mut events: MessageReader<ChunkGpuDataReady>,
 /// ) {
 ///     for event in events.read() {
 ///         println!("Received GPU data for chunk {:?}", event.chunk_coords);
@@ -276,7 +276,7 @@ pub struct CpuToGpuCopyRequest {
 ///     }
 /// }
 /// ```
-#[derive(Event, Debug)]
+#[derive(Message, Debug)]
 pub struct ChunkGpuDataReady {
     /// World coordinates of the chunk whose data was transferred.
     /// 数据已传输的区块的世界坐标
@@ -323,7 +323,7 @@ pub struct ChunkGpuDataReady {
 /// # use bevy_fog_of_war::prelude::*;
 /// # use bevy::prelude::*;
 /// fn handle_cpu_data_uploaded(
-///     mut events: EventReader<ChunkCpuDataUploaded>,
+///     mut events: MessageReader<ChunkCpuDataUploaded>,
 ///     mut cache: ResMut<ChunkStateCache>,
 /// ) {
 ///     for event in events.read() {
@@ -337,7 +337,7 @@ pub struct ChunkGpuDataReady {
 ///     }
 /// }
 /// ```
-#[derive(Event, Debug)]
+#[derive(Message, Debug)]
 pub struct ChunkCpuDataUploaded {
     /// World coordinates of the chunk that was uploaded to GPU.
     /// 已上传到 GPU 的区块的世界坐标
@@ -583,12 +583,12 @@ impl TextureSizeCalculator {
 
 /// 事件：重置所有雾效数据，包括已探索区域、可见性状态和纹理数据。
 /// Event: Reset all fog of war data, including explored areas, visibility states, and texture data.
-#[derive(Event, Debug, Default)]
+#[derive(Message, Debug, Default)]
 pub struct ResetFogOfWar;
 
 /// 事件：雾效重置成功完成
 /// Event: Fog of war reset completed successfully
-#[derive(Event, Debug, Default)]
+#[derive(Message, Debug, Default)]
 pub struct FogResetSuccess {
     /// 重置持续时间（毫秒）
     /// Reset duration in milliseconds
@@ -600,7 +600,7 @@ pub struct FogResetSuccess {
 
 /// 事件：雾效重置失败
 /// Event: Fog of war reset failed
-#[derive(Event, Debug)]
+#[derive(Message, Debug)]
 pub struct FogResetFailed {
     /// 失败原因
     /// Failure reason

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ use bevy_asset::{Assets, RenderAssetUsages};
 use bevy_image::{Image, ImageSampler, ImageSamplerDescriptor};
 use bevy_math::{IVec2, Rect, Vec2};
 use bevy_platform::collections::HashSet;
-use bevy_render::camera::RenderTarget;
+use bevy_camera::{Camera, Projection, RenderTarget};
 use bevy_render::extract_component::ExtractComponentPlugin;
 use bevy_render::extract_resource::ExtractResourcePlugin;
 use bevy_render::render_resource::{Extent3d, TextureDimension, TextureUsages};
@@ -97,7 +97,7 @@ mod texture_handles;
 /// - A chunk becomes explored for the first time
 /// - A chunk transitions from explored to visible
 /// - A chunk re-enters visibility after being out of sight
-#[derive(Event, Debug, Clone, Copy)]
+#[derive(Message, Debug, Clone, Copy)]
 pub struct RequestChunkSnapshot(pub IVec2);
 
 /// System sets that define the execution order of fog of war systems.
@@ -244,12 +244,12 @@ impl Plugin for FogOfWarPlugin {
             .init_resource::<MainWorldSnapshotRequestQueue>()
             .init_resource::<FogResetSync>();
 
-        app.add_event::<ChunkGpuDataReady>()
-            .add_event::<ChunkCpuDataUploaded>()
-            .add_event::<RequestChunkSnapshot>() // Added event for remaking snapshots / 添加用于重制快照的事件
-            .add_event::<ResetFogOfWar>() // Added event for resetting fog of war / 添加用于重置雾效的事件
-            .add_event::<FogResetSuccess>() // Added event for successful reset / 添加用于成功重置的事件
-            .add_event::<FogResetFailed>(); // Added event for failed reset / 添加用于失败重置的事件
+        app.add_message::<ChunkGpuDataReady>()
+            .add_message::<ChunkCpuDataUploaded>()
+            .add_message::<RequestChunkSnapshot>() // Added event for remaking snapshots / 添加用于重制快照的事件
+            .add_message::<ResetFogOfWar>() // Added event for resetting fog of war / 添加用于重置雾效的事件
+            .add_message::<FogResetSuccess>() // Added event for successful reset / 添加用于成功重置的事件
+            .add_message::<FogResetFailed>(); // Added event for failed reset / 添加用于失败重置的事件
 
         app.add_plugins(ExtractResourcePlugin::<GpuToCpuCopyRequests>::default())
             .add_plugins(ExtractResourcePlugin::<CpuToGpuCopyRequests>::default())
@@ -548,15 +548,16 @@ fn update_camera_view_chunks(
     mut cache: ResMut<ChunkStateCache>,
     // Assuming a single primary 2D camera with OrthographicProjection
     // 假设有一个带 OrthographicProjection 的主 2D 相机
-    camera_q: Query<(&Camera, &GlobalTransform, &Projection)>,
+    camera_q: Query<(&Camera, &GlobalTransform, &Projection, Option<&RenderTarget>)>,
 ) {
     let chunk_size = settings.chunk_size.as_vec2();
 
-    for (camera, cam_transform, projection) in camera_q.iter() {
+    for (camera, cam_transform, projection, render_target) in camera_q.iter() {
         if let Projection::Orthographic(projection) = projection {
             // Consider only the active camera targeting the primary window
             // 只考虑渲染到主窗口的活动相机
-            if !camera.is_active || !matches!(camera.target, RenderTarget::Window(_)) {
+            let targets_window = render_target.map_or(true, |rt| matches!(rt, RenderTarget::Window(_)));
+            if !camera.is_active || !targets_window {
                 continue;
             }
 
@@ -595,7 +596,7 @@ fn update_chunk_component_state(
     cache: Res<ChunkStateCache>,
     chunk_manager: Res<ChunkEntityManager>,
     mut chunk_q: Query<&mut FogChunk>,
-    mut snapshot_event_writer: EventWriter<RequestChunkSnapshot>, // Changed to EventWriter / 更改为 EventWriter
+    mut snapshot_event_writer: MessageWriter<RequestChunkSnapshot>, // Changed to EventWriter / 更改为 EventWriter
 ) {
     for (coords, entity) in chunk_manager.map.iter() {
         if let Ok(mut chunk) = chunk_q.get_mut(*entity) {
@@ -862,8 +863,8 @@ pub fn manage_chunk_texture_transfer(
     mut texture_manager: ResMut<TextureArrayManager>,
     mut gpu_to_cpu_requests: ResMut<GpuToCpuCopyRequests>,
     mut cpu_to_gpu_requests: ResMut<CpuToGpuCopyRequests>,
-    mut gpu_data_ready_reader: EventReader<ChunkGpuDataReady>,
-    mut cpu_data_uploaded_reader: EventReader<ChunkCpuDataUploaded>,
+    mut gpu_data_ready_reader: MessageReader<ChunkGpuDataReady>,
+    mut cpu_data_uploaded_reader: MessageReader<ChunkCpuDataUploaded>,
     mut snapshot_requests: ResMut<MainWorldSnapshotRequestQueue>,
 ) {
     for event in gpu_data_ready_reader.read() {
@@ -1117,7 +1118,7 @@ pub fn manage_chunk_texture_transfer(
 /// Refactored to 4 parameters to reduce coupling.
 #[allow(clippy::too_many_arguments)]
 fn reset_fog_of_war_system(
-    mut events: EventReader<ResetFogOfWar>,
+    mut events: MessageReader<ResetFogOfWar>,
     mut cache: ResMut<ChunkStateCache>,
     mut chunk_q: Query<&mut FogChunk>,
     mut chunk_query: Query<(Entity, &mut FogChunkImage)>,
@@ -1454,8 +1455,8 @@ fn monitor_reset_sync_system(
     mut reset_sync: ResMut<FogResetSync>,
     mut cache: ResMut<ChunkStateCache>,
     time: Res<Time>,
-    mut success_events: EventWriter<FogResetSuccess>,
-    mut failure_events: EventWriter<FogResetFailed>,
+    mut success_events: MessageWriter<FogResetSuccess>,
+    mut failure_events: MessageWriter<FogResetFailed>,
 ) {
     let current_time = time.elapsed().as_millis() as u64;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,10 +59,10 @@ use self::prelude::*;
 use crate::persistence::FogOfWarPersistencePlugin;
 use crate::render::FogOfWarRenderPlugin;
 use bevy_asset::{Assets, RenderAssetUsages};
+use bevy_camera::{Camera, Projection, RenderTarget};
 use bevy_image::{Image, ImageSampler, ImageSamplerDescriptor};
 use bevy_math::{IVec2, Rect, Vec2};
 use bevy_platform::collections::HashSet;
-use bevy_camera::{Camera, Projection, RenderTarget};
 use bevy_render::extract_component::ExtractComponentPlugin;
 use bevy_render::extract_resource::ExtractResourcePlugin;
 use bevy_render::render_resource::{Extent3d, TextureDimension, TextureUsages};
@@ -548,7 +548,12 @@ fn update_camera_view_chunks(
     mut cache: ResMut<ChunkStateCache>,
     // Assuming a single primary 2D camera with OrthographicProjection
     // 假设有一个带 OrthographicProjection 的主 2D 相机
-    camera_q: Query<(&Camera, &GlobalTransform, &Projection, Option<&RenderTarget>)>,
+    camera_q: Query<(
+        &Camera,
+        &GlobalTransform,
+        &Projection,
+        Option<&RenderTarget>,
+    )>,
 ) {
     let chunk_size = settings.chunk_size.as_vec2();
 
@@ -556,7 +561,8 @@ fn update_camera_view_chunks(
         if let Projection::Orthographic(projection) = projection {
             // Consider only the active camera targeting the primary window
             // 只考虑渲染到主窗口的活动相机
-            let targets_window = render_target.map_or(true, |rt| matches!(rt, RenderTarget::Window(_)));
+            let targets_window =
+                render_target.is_none_or(|rt| matches!(rt, RenderTarget::Window(_)));
             if !camera.is_active || !targets_window {
                 continue;
             }

--- a/src/managers.rs
+++ b/src/managers.rs
@@ -1061,7 +1061,7 @@ impl TextureArrayManager {
     /// # Integration with Game Events
     /// ```rust,ignore
     /// fn handle_new_game_event(
-    ///     mut new_game_events: EventReader<NewGameEvent>,
+    ///     mut new_game_events: MessageReader<NewGameEvent>,
     ///     mut manager: ResMut<TextureArrayManager>,
     ///     mut cache: ResMut<ChunkStateCache>,
     /// ) {

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -442,7 +442,7 @@ pub struct SaveMetadata {
 
 /// 请求保存雾效数据的事件
 /// Event to request saving fog of war data
-#[derive(Event, Debug, Clone)]
+#[derive(Message, Debug, Clone)]
 pub struct SaveFogOfWarRequest {
     /// 是否包含纹理数据
     /// Whether to include texture data
@@ -454,7 +454,7 @@ pub struct SaveFogOfWarRequest {
 
 /// 请求加载雾效数据的事件
 /// Event to request loading fog of war data
-#[derive(Event, Debug, Clone)]
+#[derive(Message, Debug, Clone)]
 pub struct LoadFogOfWarRequest {
     /// 要加载的序列化数据
     /// Serialized data to load
@@ -466,7 +466,7 @@ pub struct LoadFogOfWarRequest {
 
 /// 雾效数据保存完成事件
 /// Event emitted when fog of war data is saved
-#[derive(Event, Debug, Clone)]
+#[derive(Message, Debug, Clone)]
 pub struct FogOfWarSaved {
     /// 序列化的数据
     /// Serialized data
@@ -481,7 +481,7 @@ pub struct FogOfWarSaved {
 
 /// 雾效数据加载完成事件
 /// Event emitted when fog of war data is loaded
-#[derive(Event, Debug, Clone)]
+#[derive(Message, Debug, Clone)]
 pub struct FogOfWarLoaded {
     /// 加载的区块数量
     /// Number of chunks loaded
@@ -740,13 +740,13 @@ pub fn load_save_data(
     // Use deferred command to ensure ensure_snapshot_render_layer runs before snapshot requests
     if !chunks_needing_snapshots.is_empty() {
         commands.queue(move |world: &mut World| {
-            let mut snapshot_events = world.resource_mut::<Events<RequestChunkSnapshot>>();
+            let mut snapshot_events = world.resource_mut::<Messages<RequestChunkSnapshot>>();
             for chunk_coords in chunks_needing_snapshots {
                 info!(
                     "Sending deferred RequestChunkSnapshot for chunk {:?}",
                     chunk_coords
                 );
-                snapshot_events.send(RequestChunkSnapshot(chunk_coords));
+                snapshot_events.write(RequestChunkSnapshot(chunk_coords));
             }
         });
     }
@@ -758,10 +758,10 @@ pub fn load_save_data(
 /// Save system parameter bundle
 #[derive(SystemParam)]
 pub struct SaveSystemParams<'w, 's> {
-    save_events: EventReader<'w, 's, SaveFogOfWarRequest>,
+    save_events: MessageReader<'w, 's, SaveFogOfWarRequest>,
     pending_saves: ResMut<'w, PendingSaveOperations>,
     gpu_to_cpu_requests: ResMut<'w, GpuToCpuCopyRequests>,
-    saved_events: EventWriter<'w, FogOfWarSaved>,
+    saved_events: MessageWriter<'w, FogOfWarSaved>,
     settings: Res<'w, FogMapSettings>,
     cache: Res<'w, ChunkStateCache>,
     chunks: Query<'w, 's, &'static FogChunk>,
@@ -956,9 +956,9 @@ pub fn save_fog_of_war_system(mut params: SaveSystemParams) {
 ///
 /// # Time Complexity: O(pending_chunks) per event, O(total_texture_data) for save completion
 pub fn handle_gpu_data_ready_system(
-    mut gpu_ready_events: EventReader<ChunkGpuDataReady>,
+    mut gpu_ready_events: MessageReader<ChunkGpuDataReady>,
     mut pending_saves: ResMut<PendingSaveOperations>,
-    mut saved_events: EventWriter<FogOfWarSaved>,
+    mut saved_events: MessageWriter<FogOfWarSaved>,
     settings: Res<FogMapSettings>,
 ) {
     for event in gpu_ready_events.read() {
@@ -1208,7 +1208,7 @@ fn create_save_data_immediate(
 fn complete_save_operation(
     save_data: FogOfWarSaveData,
     format: SerializationFormat,
-    saved_events: &mut EventWriter<FogOfWarSaved>,
+    saved_events: &mut MessageWriter<FogOfWarSaved>,
 ) {
     let result = match format {
         #[cfg(feature = "format-json")]
@@ -1253,8 +1253,8 @@ fn complete_save_operation(
 /// Load system parameter bundle
 #[derive(SystemParam)]
 pub struct LoadSystemParams<'w, 's> {
-    load_events: EventReader<'w, 's, LoadFogOfWarRequest>,
-    loaded_events: EventWriter<'w, FogOfWarLoaded>,
+    load_events: MessageReader<'w, 's, LoadFogOfWarRequest>,
+    loaded_events: MessageWriter<'w, FogOfWarLoaded>,
     commands: Commands<'w, 's>,
     settings: Res<'w, FogMapSettings>,
     cache: ResMut<'w, ChunkStateCache>,
@@ -1526,7 +1526,7 @@ pub fn load_fog_of_war_system(mut params: LoadSystemParams) {
 /// ```rust,no_run
 /// # use bevy::prelude::*;
 /// # use bevy_fog_of_war::prelude::*;
-/// fn save_fog_state(mut save_events: EventWriter<SaveFogOfWarRequest>) {
+/// fn save_fog_state(mut save_events: MessageWriter<SaveFogOfWarRequest>) {
 ///     save_events.send(SaveFogOfWarRequest {
 ///         include_texture_data: true,  // Complete save with GPU data
 ///         format: Some(SerializationFormat::Bincode),
@@ -1539,7 +1539,7 @@ pub fn load_fog_of_war_system(mut params: LoadSystemParams) {
 /// # use bevy::prelude::*;
 /// # use bevy_fog_of_war::prelude::*;
 /// fn load_fog_state(
-///     mut load_events: EventWriter<LoadFogOfWarRequest>,
+///     mut load_events: MessageWriter<LoadFogOfWarRequest>,
 ///     save_data: Vec<u8>  // Previously saved data
 /// ) {
 ///     load_events.send(LoadFogOfWarRequest {
@@ -1595,10 +1595,10 @@ pub struct FogOfWarPersistencePlugin;
 
 impl Plugin for FogOfWarPersistencePlugin {
     fn build(&self, app: &mut App) {
-        app.add_event::<SaveFogOfWarRequest>()
-            .add_event::<LoadFogOfWarRequest>()
-            .add_event::<FogOfWarSaved>()
-            .add_event::<FogOfWarLoaded>()
+        app.add_message::<SaveFogOfWarRequest>()
+            .add_message::<LoadFogOfWarRequest>()
+            .add_message::<FogOfWarSaved>()
+            .add_message::<FogOfWarLoaded>()
             .init_resource::<PendingSaveOperations>()
             .add_systems(
                 Update,

--- a/src/persistence_utils.rs
+++ b/src/persistence_utils.rs
@@ -457,43 +457,31 @@ impl FileFormat {
     pub fn from_extension(path: &Path) -> Option<Self> {
         let ext = path.extension()?.to_str()?;
 
-        // 检查双扩展名（如 .json.gz, .msgpack.lz4等）
         // Check for double extensions (like .json.gz, .msgpack.lz4, etc.)
-        if let Some(stem) = path.file_stem() {
-            if let Some(stem_str) = stem.to_str() {
-                if stem_str.ends_with(".json") {
-                    match ext {
-                        #[cfg(all(feature = "format-json", feature = "compression-gzip"))]
-                        "gz" => return Some(FileFormat::JsonGzip),
-                        #[cfg(all(feature = "format-json", feature = "compression-lz4"))]
-                        "lz4" => return Some(FileFormat::JsonLz4),
-                        #[cfg(all(feature = "format-json", feature = "compression-zstd"))]
-                        "zst" => return Some(FileFormat::JsonZstd),
-                        _ => {}
-                    }
-                } else if stem_str.ends_with(".msgpack") {
-                    match ext {
-                        #[cfg(all(feature = "format-messagepack", feature = "compression-gzip"))]
-                        "gz" => return Some(FileFormat::MessagePackGzip),
-                        #[cfg(all(feature = "format-messagepack", feature = "compression-lz4"))]
-                        "lz4" => return Some(FileFormat::MessagePackLz4),
-                        #[cfg(all(feature = "format-messagepack", feature = "compression-zstd"))]
-                        "zst" => return Some(FileFormat::MessagePackZstd),
-                        _ => {}
-                    }
-                } else if stem_str.ends_with(".bincode") {
-                    match ext {
-                        #[cfg(all(feature = "format-bincode", feature = "compression-gzip"))]
-                        "gz" => return Some(FileFormat::BincodeGzip),
-                        #[cfg(all(feature = "format-bincode", feature = "compression-lz4"))]
-                        "lz4" => return Some(FileFormat::BincodeLz4),
-                        #[cfg(all(feature = "format-bincode", feature = "compression-zstd"))]
-                        "zst" => return Some(FileFormat::BincodeZstd),
-                        _ => {}
-                    }
-                }
+        if let Some(stem_str) = path.file_stem().and_then(|s| s.to_str()) {
+            match (stem_str, ext) {
+                #[cfg(all(feature = "format-json", feature = "compression-gzip"))]
+                (s, "gz") if s.ends_with(".json") => return Some(FileFormat::JsonGzip),
+                #[cfg(all(feature = "format-json", feature = "compression-lz4"))]
+                (s, "lz4") if s.ends_with(".json") => return Some(FileFormat::JsonLz4),
+                #[cfg(all(feature = "format-json", feature = "compression-zstd"))]
+                (s, "zst") if s.ends_with(".json") => return Some(FileFormat::JsonZstd),
+                #[cfg(all(feature = "format-messagepack", feature = "compression-gzip"))]
+                (s, "gz") if s.ends_with(".msgpack") => return Some(FileFormat::MessagePackGzip),
+                #[cfg(all(feature = "format-messagepack", feature = "compression-lz4"))]
+                (s, "lz4") if s.ends_with(".msgpack") => return Some(FileFormat::MessagePackLz4),
+                #[cfg(all(feature = "format-messagepack", feature = "compression-zstd"))]
+                (s, "zst") if s.ends_with(".msgpack") => return Some(FileFormat::MessagePackZstd),
+                #[cfg(all(feature = "format-bincode", feature = "compression-gzip"))]
+                (s, "gz") if s.ends_with(".bincode") => return Some(FileFormat::BincodeGzip),
+                #[cfg(all(feature = "format-bincode", feature = "compression-lz4"))]
+                (s, "lz4") if s.ends_with(".bincode") => return Some(FileFormat::BincodeLz4),
+                #[cfg(all(feature = "format-bincode", feature = "compression-zstd"))]
+                (s, "zst") if s.ends_with(".bincode") => return Some(FileFormat::BincodeZstd),
+                _ => {}
             }
         }
+
 
         // 单扩展名
         // Single extension

--- a/src/render/compute.rs
+++ b/src/render/compute.rs
@@ -104,13 +104,13 @@ use bevy_ecs::prelude::*;
 use bevy_render::{
     render_graph::{Node, NodeRunError, RenderGraphContext, RenderLabel},
     render_resource::{
-        BindGroupLayout, BindGroupLayoutEntries, CachedComputePipelineId, ComputePassDescriptor,
-        ComputePipelineDescriptor, PipelineCache, ShaderStages,
+        BindGroupLayoutDescriptor, BindGroupLayoutEntries, CachedComputePipelineId,
+        ComputePassDescriptor, ComputePipelineDescriptor, PipelineCache, ShaderStages,
         StorageTextureAccess::{ReadWrite, WriteOnly},
         TextureFormat,
         binding_types::{storage_buffer_read_only, texture_storage_2d_array, uniform_buffer},
     },
-    renderer::{RenderContext, RenderDevice},
+    renderer::{RenderContext},
 };
 
 /// Path to the WGSL compute shader file that implements fog visibility calculations.
@@ -239,7 +239,7 @@ pub struct FogComputePipeline {
     /// This layout specifies how CPU resources (textures, buffers, uniforms)
     /// are bound to GPU shader inputs. It's used to create bind groups that
     /// provide data to the compute shader during execution.
-    pub compute_layout: BindGroupLayout,
+    pub compute_layout: BindGroupLayoutDescriptor,
 }
 
 /// Initializes the fog compute pipeline from world resources during application startup.
@@ -309,11 +309,7 @@ impl FromWorld for FogComputePipeline {
     /// O(1) for resource access and pipeline queuing, but shader compilation
     /// happens asynchronously and may take additional time.
     fn from_world(world: &mut World) -> Self {
-        let pipeline_cache = world.resource::<PipelineCache>();
-
-        let render_device = world.resource::<RenderDevice>();
-
-        let compute_layout = render_device.create_bind_group_layout(
+        let compute_layout = BindGroupLayoutDescriptor::new(
             "fog_compute_bind_group_layout",
             &BindGroupLayoutEntries::sequential(
                 ShaderStages::COMPUTE,
@@ -329,15 +325,18 @@ impl FromWorld for FogComputePipeline {
 
         let shader = world.load_asset(SHADER_ASSET_PATH);
 
-        let pipeline_id = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-            label: Some("fog_compute_pipeline".into()),
-            layout: vec![compute_layout.clone()], // Use the prepared layout / 使用准备好的布局
-            shader,
-            shader_defs: vec![], // Add shader defs if needed / 如果需要添加 shader defs
-            entry_point: "main".into(),
-            push_constant_ranges: vec![],
-            zero_initialize_workgroup_memory: false,
-        });
+        let pipeline_id =
+            world
+                .resource_mut::<PipelineCache>()
+                .queue_compute_pipeline(ComputePipelineDescriptor {
+                    label: Some("fog_compute_pipeline".into()),
+                    layout: vec![compute_layout.clone()], // Use the prepared layout / 使用准备好的布局
+                    shader,
+                    shader_defs: vec![], // Add shader defs if needed / 如果需要添加 shader defs
+                    entry_point: None, // Use default entry point "main"
+                    push_constant_ranges: vec![],
+                    zero_initialize_workgroup_memory: false,
+                });
 
         FogComputePipeline {
             pipeline_id,

--- a/src/render/compute.rs
+++ b/src/render/compute.rs
@@ -110,7 +110,7 @@ use bevy_render::{
         TextureFormat,
         binding_types::{storage_buffer_read_only, texture_storage_2d_array, uniform_buffer},
     },
-    renderer::{RenderContext},
+    renderer::RenderContext,
 };
 
 /// Path to the WGSL compute shader file that implements fog visibility calculations.
@@ -325,18 +325,17 @@ impl FromWorld for FogComputePipeline {
 
         let shader = world.load_asset(SHADER_ASSET_PATH);
 
-        let pipeline_id =
-            world
-                .resource_mut::<PipelineCache>()
-                .queue_compute_pipeline(ComputePipelineDescriptor {
-                    label: Some("fog_compute_pipeline".into()),
-                    layout: vec![compute_layout.clone()], // Use the prepared layout / 使用准备好的布局
-                    shader,
-                    shader_defs: vec![], // Add shader defs if needed / 如果需要添加 shader defs
-                    entry_point: None, // Use default entry point "main"
-                    push_constant_ranges: vec![],
-                    zero_initialize_workgroup_memory: false,
-                });
+        let pipeline_id = world
+            .resource_mut::<PipelineCache>()
+            .queue_compute_pipeline(ComputePipelineDescriptor {
+                label: Some("fog_compute_pipeline".into()),
+                layout: vec![compute_layout.clone()], // Use the prepared layout / 使用准备好的布局
+                shader,
+                shader_defs: vec![], // Add shader defs if needed / 如果需要添加 shader defs
+                entry_point: None,   // Use default entry point "main"
+                push_constant_ranges: vec![],
+                zero_initialize_workgroup_memory: false,
+            });
 
         FogComputePipeline {
             pipeline_id,

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -100,7 +100,8 @@ use bevy_asset::Handle;
 use bevy_color::ColorToComponents;
 use bevy_derive::{Deref, DerefMut};
 use bevy_image::Image;
-use bevy_math::{IVec2, Rect, UVec2, Vec2, Vec4};
+use bevy_camera::Projection;
+use bevy_math::{IVec2, Rect, UVec2, Vec2, Vec3, Vec4};
 use bevy_render::Extract;
 use bevy_render::render_resource::ShaderType;
 use bevy_transform::components::GlobalTransform;
@@ -887,7 +888,7 @@ pub fn extract_gpu_chunk_data(
         // Calculate view AABB for an orthographic camera
         // This assumes the FogOfWarCamera is orthographic. Handle perspective if needed.
         if let Projection::Orthographic(ortho_projection) = projection {
-            let camera_scale = camera_transform.compute_transform().scale;
+            let camera_scale: Vec3 = camera_transform.compute_transform().scale;
             // ortho_projection.area gives the size of the projection area.
             // For WindowSize scale mode, this area is in logical pixels, needing viewport size.
             // For Fixed scale mode, this area is in world units.

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -97,10 +97,10 @@
 
 use crate::prelude::*;
 use bevy_asset::Handle;
+use bevy_camera::Projection;
 use bevy_color::ColorToComponents;
 use bevy_derive::{Deref, DerefMut};
 use bevy_image::Image;
-use bevy_camera::Projection;
 use bevy_math::{IVec2, Rect, UVec2, Vec2, Vec3, Vec4};
 use bevy_render::Extract;
 use bevy_render::render_resource::ShaderType;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -67,9 +67,9 @@
 
 use crate::prelude::*;
 use bevy_core_pipeline::core_2d::graph::{Core2d, Node2d};
-use bevy_render::render_graph::{RenderGraphApp, ViewNodeRunner};
+use bevy_render::render_graph::{RenderGraphExt, ViewNodeRunner};
 use bevy_render::renderer::render_system;
-use bevy_render::{Render, RenderApp, RenderSet};
+use bevy_render::{Render, RenderApp, RenderSystems};
 
 // Render pipeline submodules
 // 渲染管线子模块
@@ -208,7 +208,7 @@ impl Plugin for FogOfWarRenderPlugin {
                 Render,
                 (
                     // CPU -> GPU
-                    (transfer::process_cpu_to_gpu_copies,).in_set(RenderSet::PrepareResources),
+                    (transfer::process_cpu_to_gpu_copies,).in_set(RenderSystems::PrepareResources),
                     // GPU -> CPU - Stage 1: Initiate copy and request map
                     // Run this after rendering/compute that populates the textures for the current frame.
                     // CleanupCommands is a good place.
@@ -217,7 +217,7 @@ impl Plugin for FogOfWarRenderPlugin {
                         transfer::map_buffers,
                     )
                         .after(render_system)
-                        .in_set(RenderSet::Render),
+                        .in_set(RenderSystems::Render),
                     // GPU -> CPU - Stage 2: Check for mapped buffers and process them
                     // Run this in the *next* frame, typically early (e.g., Prepare).
                     // Or, if your game loop/framerate allows, and map_async is fast on your GPU,
@@ -236,7 +236,7 @@ impl Plugin for FogOfWarRenderPlugin {
                     prepare::prepare_overlay_chunk_mapping_buffer,
                     prepare::prepare_fog_bind_groups,
                 )
-                    .in_set(RenderSet::PrepareBindGroups),
+                    .in_set(RenderSystems::PrepareBindGroups),
             );
 
         // Add Render Graph nodes / 添加 Render Graph 节点

--- a/src/render/overlay.rs
+++ b/src/render/overlay.rs
@@ -368,13 +368,13 @@ impl FromWorld for FogOverlayPipeline {
                     vertex: VertexState {
                         shader: fullscreen_shader, // Bevy's built-in fullscreen vertex shader
                         shader_defs: vec![],       // No shader preprocessor definitions
-                        entry_point: None, // Use default entry point from shader
-                        buffers: vec![], // No vertex buffers (fullscreen triangle)
+                        entry_point: None,         // Use default entry point from shader
+                        buffers: vec![],           // No vertex buffers (fullscreen triangle)
                     },
                     fragment: Some(FragmentState {
-                        shader,                         // Custom fog overlay fragment shader
-                        shader_defs: vec![],            // No shader preprocessor definitions
-                        entry_point: None, // Use default entry point from shader
+                        shader,              // Custom fog overlay fragment shader
+                        shader_defs: vec![], // No shader preprocessor definitions
+                        entry_point: None,   // Use default entry point from shader
                         targets: vec![Some(ColorTargetState {
                             format: TextureFormat::bevy_default(), // Use Bevy's default HDR format
                             blend: Some(BlendState::ALPHA_BLENDING), // Standard alpha blending for transparency

--- a/src/render/overlay.rs
+++ b/src/render/overlay.rs
@@ -112,7 +112,7 @@ use super::extract::{
 use super::prepare::{FogUniforms, OverlayChunkMappingBuffer};
 use crate::snapshot::SnapshotCamera;
 use bevy_asset::DirectAssetAccessExt;
-use bevy_core_pipeline::fullscreen_vertex_shader::FULLSCREEN_SHADER_HANDLE;
+use bevy_core_pipeline::FullscreenShader;
 use bevy_ecs::prelude::*;
 use bevy_ecs::query::QueryItem;
 use bevy_ecs::system::lifetimeless::Read;
@@ -249,7 +249,7 @@ pub struct FogOverlayPipeline {
     ///
     /// This layout specifies how CPU resources (textures, buffers, uniforms)
     /// are bound to GPU shader inputs. Used to create bind groups for overlay rendering.
-    layout: BindGroupLayout,
+    layout: BindGroupLayoutDescriptor,
 
     /// Shared texture sampler for all fog texture array operations.
     /// 用于所有雾效纹理数组操作的共享纹理采样器
@@ -318,9 +318,9 @@ impl FromWorld for FogOverlayPipeline {
     fn from_world(world: &mut World) -> Self {
         let render_device = world.resource::<RenderDevice>();
 
-        // Create bind group layout defining shader resource binding schema
-        // 创建定义着色器资源绑定模式的绑定组布局
-        let layout = render_device.create_bind_group_layout(
+        // Create bind group layout descriptor (Bevy 0.18: BindGroupLayoutDescriptor not BindGroupLayout)
+        // 创建绑定组布局描述符 (Bevy 0.18: BindGroupLayoutDescriptor 而非 BindGroupLayout)
+        let layout = BindGroupLayoutDescriptor::new(
             "fog_overlay_bind_group_layout",
             &BindGroupLayoutEntries::sequential(
                 ShaderStages::FRAGMENT,
@@ -353,6 +353,10 @@ impl FromWorld for FogOverlayPipeline {
         // 加载雾效覆盖片段着色器资源
         let shader = world.load_asset(SHADER_ASSET_PATH);
 
+        // Get the fullscreen vertex shader handle from the FullscreenShader resource
+        // 从 FullscreenShader 资源获取全屏顶点着色器句柄
+        let fullscreen_shader = world.resource::<FullscreenShader>().shader().clone();
+
         // Queue render pipeline for compilation with complete configuration
         // 排队渲染管线以进行完整配置的编译
         let pipeline_id =
@@ -362,15 +366,15 @@ impl FromWorld for FogOverlayPipeline {
                     label: Some("fog_overlay_pipeline_init".into()), // Pipeline identifier for debugging
                     layout: vec![layout.clone()], // Use the bind group layout created above
                     vertex: VertexState {
-                        shader: FULLSCREEN_SHADER_HANDLE, // Bevy's built-in fullscreen vertex shader
-                        shader_defs: vec![],              // No shader preprocessor definitions
-                        entry_point: "fullscreen_vertex_shader".into(), // Standard vertex entry point
+                        shader: fullscreen_shader, // Bevy's built-in fullscreen vertex shader
+                        shader_defs: vec![],       // No shader preprocessor definitions
+                        entry_point: None, // Use default entry point from shader
                         buffers: vec![], // No vertex buffers (fullscreen triangle)
                     },
                     fragment: Some(FragmentState {
                         shader,                         // Custom fog overlay fragment shader
                         shader_defs: vec![],            // No shader preprocessor definitions
-                        entry_point: "fragment".into(), // Fragment shader entry point
+                        entry_point: None, // Use default entry point from shader
                         targets: vec![Some(ColorTargetState {
                             format: TextureFormat::bevy_default(), // Use Bevy's default HDR format
                             blend: Some(BlendState::ALPHA_BLENDING), // Standard alpha blending for transparency
@@ -387,7 +391,7 @@ impl FromWorld for FogOverlayPipeline {
         // Return configured pipeline with all components
         // 返回包含所有组件的配置管线
         FogOverlayPipeline {
-            layout,      // Bind group layout for resource binding
+            layout,      // Bind group layout descriptor for resource binding
             sampler,     // Texture sampler for filtering
             pipeline_id, // Cached pipeline ID for runtime retrieval
         }
@@ -541,9 +545,11 @@ impl ViewNode for FogOverlayNode {
 
         // Create view-specific bind group with all required GPU resources
         // 创建包含所有必需GPU资源的视图特定绑定组
+        // Bevy 0.18: use pipeline_cache.get_bind_group_layout() to resolve descriptor
+        let overlay_layout = pipeline_cache.get_bind_group_layout(&overlay_pipeline.layout);
         let bind_group = render_context.render_device().create_bind_group(
             "fog_overlay_bind_group",
-            &overlay_pipeline.layout,
+            &overlay_layout,
             &BindGroupEntries::sequential((
                 view_uniform_binding,            // 0: Camera view uniforms (with dynamic offset)
                 &overlay_pipeline.sampler,       // 1: Linear filtering sampler for textures
@@ -562,6 +568,7 @@ impl ViewNode for FogOverlayNode {
             color_attachments: &[Some(RenderPassColorAttachment {
                 view: view_target.main_texture_view(), // Render to main view target
                 resolve_target: None,                  // No MSAA resolve needed
+                depth_slice: None,                     // No depth slice for 2D overlay
                 ops: Operations {
                     load: LoadOp::Load,    // Load existing scene content
                     store: StoreOp::Store, // Store final composited result

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -704,13 +704,14 @@ pub fn prepare_fog_bind_groups(
     ) {
         // Bevy 0.18: get actual BindGroupLayout from descriptor via pipeline_cache
         // Bevy 0.18: 通过 pipeline_cache 从描述符获取实际的 BindGroupLayout
-        let compute_layout = pipeline_cache.get_bind_group_layout(&fog_compute_pipeline.compute_layout);
+        let compute_layout =
+            pipeline_cache.get_bind_group_layout(&fog_compute_pipeline.compute_layout);
 
         // Create compute bind group with all required resources for fog calculations
         // 创建包含雾效计算所需所有资源的计算绑定组
         let compute_bind_group = render_device.create_bind_group(
-            "fog_compute_bind_group",  // Debug label for GPU debugging
-            &compute_layout,           // Use the resolved BindGroupLayout
+            "fog_compute_bind_group", // Debug label for GPU debugging
+            &compute_layout,          // Use the resolved BindGroupLayout
             &BindGroupEntries::sequential((
                 fog_texture_view,                // 0: Fog texture array (write access)
                 visibility_texture_view,         // 1: Visibility texture array (read/write)

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -87,7 +87,7 @@ use crate::render::compute::FogComputePipeline;
 use bevy_ecs::prelude::*;
 use bevy_render::render_asset::RenderAssets;
 use bevy_render::render_resource::{
-    BindGroup, BindGroupEntries, Buffer, BufferInitDescriptor, BufferUsages,
+    BindGroup, BindGroupEntries, Buffer, BufferInitDescriptor, BufferUsages, PipelineCache,
 };
 use bevy_render::renderer::RenderDevice;
 use bevy_render::texture::{FallbackImage, GpuImage};
@@ -678,6 +678,7 @@ pub fn prepare_fog_bind_groups(
     images: Res<RenderAssets<GpuImage>>,
     fallback_image: Res<FallbackImage>, // For default textures / 用于默认纹理
     fog_compute_pipeline: Res<FogComputePipeline>, // For view uniform binding / 用于视图统一绑定
+    pipeline_cache: Res<PipelineCache>, // Bevy 0.18: needed to get BindGroupLayout from descriptor
 ) {
     // Get texture views with fallback support for robust resource handling
     // 获取纹理视图，支持回退以实现强大的资源处理
@@ -701,11 +702,15 @@ pub fn prepare_fog_bind_groups(
         vision_source_buffer.buffer.as_ref(), // Vision source storage buffer
         gpu_chunk_buffer.buffer.as_ref(),     // Chunk computation storage buffer
     ) {
+        // Bevy 0.18: get actual BindGroupLayout from descriptor via pipeline_cache
+        // Bevy 0.18: 通过 pipeline_cache 从描述符获取实际的 BindGroupLayout
+        let compute_layout = pipeline_cache.get_bind_group_layout(&fog_compute_pipeline.compute_layout);
+
         // Create compute bind group with all required resources for fog calculations
         // 创建包含雾效计算所需所有资源的计算绑定组
         let compute_bind_group = render_device.create_bind_group(
-            "fog_compute_bind_group",             // Debug label for GPU debugging
-            &fog_compute_pipeline.compute_layout, // Use pipeline's bind group layout
+            "fog_compute_bind_group",  // Debug label for GPU debugging
+            &compute_layout,           // Use the resolved BindGroupLayout
             &BindGroupEntries::sequential((
                 fog_texture_view,                // 0: Fog texture array (write access)
                 visibility_texture_view,         // 1: Visibility texture array (read/write)

--- a/src/render/transfer.rs
+++ b/src/render/transfer.rs
@@ -317,7 +317,7 @@ pub fn initiate_gpu_to_cpu_copies_and_request_map(
             continue;
         }
 
-        let fog_format_size = fog_format.pixel_size() as u32;
+        let fog_format_size = fog_format.pixel_size().unwrap_or(0) as u32;
         if fog_format_size == 0 {
             error!("Fog buffer size is 0 for chunk {:?}", request.chunk_coords);
             continue;
@@ -332,7 +332,7 @@ pub fn initiate_gpu_to_cpu_copies_and_request_map(
             .checked_mul(texture_height as u64)
             .expect("Fog buffer size calculation would overflow");
 
-        let snapshot_format_size = snapshot_format.pixel_size() as u32;
+        let snapshot_format_size = snapshot_format.pixel_size().unwrap_or(0) as u32;
         if snapshot_format_size == 0 {
             error!(
                 "Snapshot buffer size is 0 for chunk {:?}",
@@ -519,11 +519,13 @@ pub fn check_and_process_mapped_buffers(
         if let (Some(fog_data), Some(snapshot_data)) =
             (&pending_data.fog_result, &pending_data.snapshot_result)
         {
-            main_world.send_event(ChunkGpuDataReady {
-                chunk_coords: pending_data.original_request.chunk_coords,
-                fog_data: fog_data.clone(),
-                snapshot_data: snapshot_data.clone(),
-            });
+            if let Some(mut msgs) = main_world.get_resource_mut::<bevy_ecs::message::Messages<ChunkGpuDataReady>>() {
+                msgs.write(ChunkGpuDataReady {
+                    chunk_coords: pending_data.original_request.chunk_coords,
+                    fog_data: fog_data.clone(),
+                    snapshot_data: snapshot_data.clone(),
+                });
+            }
             false
         } else {
             true
@@ -719,7 +721,9 @@ pub(crate) fn check_cpu_to_gpu_request(
         })
         .collect::<Vec<ChunkCpuDataUploaded>>();
 
-    main_world.send_event_batch(requests);
+    if let Some(mut msgs) = main_world.get_resource_mut::<bevy_ecs::message::Messages<ChunkCpuDataUploaded>>() {
+        msgs.write_batch(requests);
+    }
 }
 
 /// 检查并清空纹理（在渲染世界中重置时）
@@ -817,7 +821,7 @@ pub fn check_and_clear_textures_on_reset(
     // 安全的雾效重置缓冲区大小计算，防止整数溢出
     // Safe fog reset buffer size calculation to prevent integer overflow
     let fog_bytes_per_row = (texture_width as u64)
-        .checked_mul(TextureFormat::R8Unorm.pixel_size() as u64)
+        .checked_mul(TextureFormat::R8Unorm.pixel_size().unwrap_or(0) as u64)
         .and_then(|v| u32::try_from(v).ok())
         .expect("Fog bytes per row calculation would overflow");
     let fog_padded_bytes_per_row =
@@ -830,7 +834,7 @@ pub fn check_and_clear_textures_on_reset(
     // 安全的可见性重置缓冲区大小计算，防止整数溢出
     // Safe visibility reset buffer size calculation to prevent integer overflow
     let vis_bytes_per_row = (texture_width as u64)
-        .checked_mul(TextureFormat::R8Unorm.pixel_size() as u64)
+        .checked_mul(TextureFormat::R8Unorm.pixel_size().unwrap_or(0) as u64)
         .and_then(|v| u32::try_from(v).ok())
         .expect("Visibility bytes per row calculation would overflow");
     let vis_padded_bytes_per_row =
@@ -843,7 +847,7 @@ pub fn check_and_clear_textures_on_reset(
     // 安全的快照重置缓冲区大小计算，防止整数溢出
     // Safe snapshot reset buffer size calculation to prevent integer overflow
     let snap_bytes_per_row = (texture_width as u64)
-        .checked_mul(TextureFormat::Rgba8Unorm.pixel_size() as u64) // RGBA already included in pixel_size
+        .checked_mul(TextureFormat::Rgba8Unorm.pixel_size().unwrap_or(0) as u64) // RGBA already included in pixel_size
         .and_then(|v| u32::try_from(v).ok())
         .expect("Snapshot bytes per row calculation would overflow");
     let snap_padded_bytes_per_row =

--- a/src/render/transfer.rs
+++ b/src/render/transfer.rs
@@ -519,7 +519,9 @@ pub fn check_and_process_mapped_buffers(
         if let (Some(fog_data), Some(snapshot_data)) =
             (&pending_data.fog_result, &pending_data.snapshot_result)
         {
-            if let Some(mut msgs) = main_world.get_resource_mut::<bevy_ecs::message::Messages<ChunkGpuDataReady>>() {
+            if let Some(mut msgs) =
+                main_world.get_resource_mut::<bevy_ecs::message::Messages<ChunkGpuDataReady>>()
+            {
                 msgs.write(ChunkGpuDataReady {
                     chunk_coords: pending_data.original_request.chunk_coords,
                     fog_data: fog_data.clone(),
@@ -721,7 +723,9 @@ pub(crate) fn check_cpu_to_gpu_request(
         })
         .collect::<Vec<ChunkCpuDataUploaded>>();
 
-    if let Some(mut msgs) = main_world.get_resource_mut::<bevy_ecs::message::Messages<ChunkCpuDataUploaded>>() {
+    if let Some(mut msgs) =
+        main_world.get_resource_mut::<bevy_ecs::message::Messages<ChunkCpuDataUploaded>>()
+    {
         msgs.write_batch(requests);
     }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4,23 +4,22 @@ use crate::{FogSystems, RequestChunkSnapshot};
 use bevy_asset::{Assets, RenderAssetUsages};
 use bevy_color::Color;
 use bevy_core_pipeline::core_2d::graph::{Core2d, Node2d};
-use bevy_core_pipeline::prelude::Camera2d;
+use bevy_camera::{Camera, Camera2d, ClearColorConfig, OrthographicProjection, Projection, RenderTarget, ScalingMode};
+use bevy_camera::visibility::RenderLayers;
 use bevy_image::Image;
 use bevy_math::{IVec2, Rect};
 use bevy_render::RenderApp;
-use bevy_render::camera::RenderTarget;
 use bevy_render::extract_component::ExtractComponent;
 use bevy_render::extract_resource::{ExtractResource, ExtractResourcePlugin};
 use bevy_render::render_asset::RenderAssets;
 use bevy_render::render_graph::{
-    Node, NodeRunError, RenderGraphApp, RenderGraphContext, RenderLabel,
+    Node, NodeRunError, RenderGraphExt, RenderGraphContext, RenderLabel,
 };
 use bevy_render::render_resource::{
     Extent3d, Origin3d, TexelCopyTextureInfo, TextureAspect, TextureDimension, TextureUsages,
 };
 use bevy_render::renderer::RenderContext;
 use bevy_render::texture::GpuImage;
-use bevy_render::view::RenderLayers;
 use bevy_transform::components::{GlobalTransform, Transform};
 
 /// Plugin for managing fog of war snapshot system that captures previously explored areas.
@@ -84,7 +83,7 @@ impl Plugin for SnapshotPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(ExtractResourcePlugin::<SnapshotCameraState>::default());
         app.init_resource::<SnapshotCameraState>();
-        app.add_event::<RequestCleanChunkSnapshot>();
+        app.add_message::<RequestCleanChunkSnapshot>();
         app.add_systems(Startup, setup_snapshot_camera)
             .add_systems(PostUpdate, prepare_snapshot_camera)
             .add_systems(Update, ensure_snapshot_render_layer)
@@ -141,7 +140,7 @@ pub struct MainWorldSnapshotRequest {
 
 /// Event to request clean a snapshot for a specific chunk.
 /// 请求为特定区块清理快照的事件。
-#[derive(Event, Debug, Clone, Copy)]
+#[derive(Message, Debug, Clone, Copy)]
 pub struct RequestCleanChunkSnapshot(pub IVec2);
 
 /// Component trigger to force a snapshot capture of specific Capturable entities.
@@ -337,7 +336,7 @@ fn setup_snapshot_camera(
         Camera2d,
         Projection::Orthographic(OrthographicProjection {
             scale: settings.chunk_size.x as f32 / settings.texture_resolution_per_chunk.x as f32,
-            scaling_mode: bevy_render::camera::ScalingMode::Fixed {
+            scaling_mode: ScalingMode::Fixed {
                 width: settings.texture_resolution_per_chunk.x as f32,
                 height: settings.texture_resolution_per_chunk.y as f32,
             },
@@ -347,10 +346,9 @@ fn setup_snapshot_camera(
             clear_color: ClearColorConfig::Custom(Color::srgba(0.0, 0.0, 0.0, 0.0)),
             order: -1,        // Render before the main camera, or as needed by graph
             is_active: false, // Initially inactive
-            hdr: false,       // Snapshots likely don't need HDR
-            target: RenderTarget::Image(snapshot_temp_handle.clone().into()),
             ..Default::default()
         },
+        RenderTarget::Image(snapshot_temp_handle.clone().into()), // RenderTarget is now a separate component in Bevy 0.18
         SnapshotCamera, // Mark it as our snapshot camera
         SNAPSHOT_RENDER_LAYER,
     ));
@@ -683,7 +681,7 @@ pub fn ensure_snapshot_render_layer(
 /// - **After**: FogSystems::UpdateChunkState (chunk states updated)
 /// - **Before**: FogSystems::ManageEntities (entities managed based on requests)
 fn handle_request_chunk_snapshot_events(
-    mut events: EventReader<RequestChunkSnapshot>,
+    mut events: MessageReader<RequestChunkSnapshot>,
     chunk_manager: Res<ChunkEntityManager>,
     chunk_query: Query<&FogChunk>, // Query for FogChunk to get its details / 查询 FogChunk 以获取其详细信息
     mut snapshot_requests: ResMut<MainWorldSnapshotRequestQueue>,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -2,10 +2,13 @@ use crate::prelude::*;
 use crate::render::{RenderSnapshotTempTexture, RenderSnapshotTexture};
 use crate::{FogSystems, RequestChunkSnapshot};
 use bevy_asset::{Assets, RenderAssetUsages};
+use bevy_camera::visibility::RenderLayers;
+use bevy_camera::{
+    Camera, Camera2d, ClearColorConfig, OrthographicProjection, Projection, RenderTarget,
+    ScalingMode,
+};
 use bevy_color::Color;
 use bevy_core_pipeline::core_2d::graph::{Core2d, Node2d};
-use bevy_camera::{Camera, Camera2d, ClearColorConfig, OrthographicProjection, Projection, RenderTarget, ScalingMode};
-use bevy_camera::visibility::RenderLayers;
 use bevy_image::Image;
 use bevy_math::{IVec2, Rect};
 use bevy_render::RenderApp;
@@ -13,7 +16,7 @@ use bevy_render::extract_component::ExtractComponent;
 use bevy_render::extract_resource::{ExtractResource, ExtractResourcePlugin};
 use bevy_render::render_asset::RenderAssets;
 use bevy_render::render_graph::{
-    Node, NodeRunError, RenderGraphExt, RenderGraphContext, RenderLabel,
+    Node, NodeRunError, RenderGraphContext, RenderGraphExt, RenderLabel,
 };
 use bevy_render::render_resource::{
     Extent3d, Origin3d, TexelCopyTextureInfo, TextureAspect, TextureDimension, TextureUsages,
@@ -349,7 +352,7 @@ fn setup_snapshot_camera(
             ..Default::default()
         },
         RenderTarget::Image(snapshot_temp_handle.clone().into()), // RenderTarget is now a separate component in Bevy 0.18
-        SnapshotCamera, // Mark it as our snapshot camera
+        SnapshotCamera,                                           // Mark it as our snapshot camera
         SNAPSHOT_RENDER_LAYER,
     ));
 }


### PR DESCRIPTION
This PR migrates the plugin from Bevy 0.16 to 0.18:
- Updated cargo dependencies to Bevy 0.18.
- - Renamed EventReader/EventWriter to MessageReader/MessageWriter for buffered events.
- - Updated Camera API (RenderTarget component, removed hdr field).
- - Fixed pixel_size() returning Result by appending .unwrap_or(0).
- - Handled FullscreenShader resource API change (method call).
- - Fixed BindGroupLayoutDescriptor and entry_point signatures.
- - Replaced send_event/send_event_batch with write/write_batch on Messages resource directly.
- - Fixed sample simple_2d to compile under Bevy 0.18.